### PR TITLE
chore: `id-token` permissions for OIDC authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     outputs:
       latest_commit: ${{ steps.git_remote.outputs.latest_commit }}
     env:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -34,6 +34,10 @@ integTask.exec(jest('integ/integ.test.ts'));
 const releaseTask = project.tasks.tryFind('release')!;
 releaseTask.exec(`npx projen ${integTask.name}`);
 
+// required for OIDC authentication
+const releaseWorkflow = project.tryFindObjectFile('.github/workflows/release.yml');
+releaseWorkflow!.addOverride('jobs.release.permissions.id-token', 'write');
+
 project.synth();
 
 function jest(args: string) {


### PR DESCRIPTION
Following instructions from https://github.com/aws-actions/configure-aws-credentials