### PR TITLE
fix: npm access set to public

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,4 +1,5 @@
 import { Cdk8sTeamJsiiProject } from '@cdk8s/projen-common';
+import { NpmAccess } from 'projen/lib/javascript';
 
 const project = new Cdk8sTeamJsiiProject({
   defaultReleaseBranch: 'main',
@@ -19,6 +20,7 @@ const project = new Cdk8sTeamJsiiProject({
       },
     },
   ],
+  npmAccess: NpmAccess.PUBLIC,
 });
 
 // ignore integ tests because we will add a dedicated task

--- a/package.json
+++ b/package.json
@@ -88,6 +88,9 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.0.0",
   "jest": {
     "testMatch": [


### PR DESCRIPTION
For scoped packages, the default access is private so we need to explicitly set to public.