### PR TITLE
chore(dependencies): upgrade cdk8s

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@typescript-eslint/parser": "^7",
     "aws-cdk": "^2.151.0",
     "aws-cdk-lib": "2.109.0",
-    "cdk8s": "2.68.4",
+    "cdk8s": "2.68.91",
     "cdk8s-cli": "^2.198.179",
     "constructs": "10.3.0",
     "eslint": "^8",
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.106.1",
-    "cdk8s": "^2.68.3",
+    "cdk8s": "^2.68.91",
     "constructs": "^10.3.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2429,18 +2429,7 @@ cdk8s-plus-25@^2.22.79:
   optionalDependencies:
     backport "8.5.0"
 
-cdk8s@2.68.4:
-  version "2.68.4"
-  resolved "https://registry.yarnpkg.com/cdk8s/-/cdk8s-2.68.4.tgz#13e64f88a5f073785558f8f70e29c36c78737dfc"
-  integrity sha512-pkTtmwi3/hPWey6XtSbvPvQcdWfX6H+g1I/HPx5X5eyW22yGEZzYfSuv4HBHBLxOsp6949OlidLZn6EDo7D+UA==
-  dependencies:
-    fast-json-patch "^3.1.1"
-    follow-redirects "^1.15.2"
-    yaml "2.3.2"
-  optionalDependencies:
-    backport "8.5.0"
-
-cdk8s@^2.68.91:
+cdk8s@2.68.91, cdk8s@^2.68.91:
   version "2.68.91"
   resolved "https://registry.yarnpkg.com/cdk8s/-/cdk8s-2.68.91.tgz#8255f80ebe4c9023edabe8154993e1e9b9fe8adb"
   integrity sha512-F3Fiq1MhEDJZ/z1tQeGLSzgC/VUIo0nR1LRZgg8v9gt52SH9+yjGcnhW7WM8wdfFyj57/UCFhQl8B2q02fq1ZQ==
@@ -3613,7 +3602,7 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.14.9, follow-redirects@^1.15.2, follow-redirects@^1.15.6:
+follow-redirects@^1.14.9, follow-redirects@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
@@ -7086,11 +7075,6 @@ yaml@1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
-
-yaml@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.2.tgz#f522db4313c671a0ca963a75670f1c12ea909144"
-  integrity sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==
 
 yaml@2.5.0, yaml@^2.2.2:
   version "2.5.0"


### PR DESCRIPTION
Since cdk8s is a peerDependency, it isn't upgraded automatically.

Resolves https://github.com/cdk8s-team/cdk8s-awscdk-resolver/issues/542